### PR TITLE
Release 2026.03.09

### DIFF
--- a/src/lib/components/molecules/resume/Experience.svelte
+++ b/src/lib/components/molecules/resume/Experience.svelte
@@ -28,8 +28,11 @@
 					<div class="company-info">
 						<small>{entry.company}</small> 
 						<small class="separator"> | </small>
-						<span class="icon"><PinIcon /></span> 
-						<small>{entry.location}</small>
+						
+						<div class="location">
+							<span class="icon"><PinIcon /></span> 
+							<small>{entry.location}</small>
+						</div>
 					</div>
 				</div>
 
@@ -58,8 +61,7 @@
 											<small class="secondment-label"><u>Secondment</u></small>
 											<small class="company">{secondment.company}</small>
 											<span class="separator">|</span>
-											<span class="icon"><PinIcon /></span>
-											<small class="location">{secondment.location}</small>
+											<span class="location"><span class="icon"><PinIcon /></span> <small>{secondment.location}</small></span>
 										  </div>
 									</div>
 									<p>{secondment.description}</p>
@@ -73,6 +75,8 @@
 	{/each}
 </div>
 <style lang="scss">
+	@use '$lib/scss/breakpoints.scss';
+
 	.resume-experience {
 		.experience {
 			display: flex;
@@ -126,11 +130,26 @@
 					flex-direction: row;
 					align-items: center;
 					gap: 2px;
+
+					@include breakpoints.for-phone-only {
+						display: flex;
+						flex-direction: column;
+						align-items: start;
+					}
 					.secondment-label {
 						margin-right: 5px;
 					}
 					.separator {
 						margin: 0 5px;
+						@include breakpoints.for-phone-only {
+							display: none;	
+						}
+					}
+					.location {
+						display: flex;
+						flex-direction: row;
+						align-items: center;
+						gap: 2px;
 					}
 				}
 				.company-name {

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -107,6 +107,9 @@
         justify-content: space-between;
         gap: 0.75rem;
         width: min(80%, 500px);
+        @include breakpoints.for-phone-only {
+            width: 90%;
+        }
         background: color-mix(in srgb, var(--color--page-background) 45%, transparent);
         border: none;
         backdrop-filter: blur(24px) saturate(120%);

--- a/src/lib/components/organisms/Resume.svelte
+++ b/src/lib/components/organisms/Resume.svelte
@@ -47,12 +47,19 @@
 
     .resume {
         border: 0.15em solid;
-        border-color: var(--colo--text);
+        border-color: var(--color--text);
         border-radius: 8px;
+		@include breakpoints.for-phone-only {
+			border: none;border-radius: 8px;
+
+		}
         padding: 0.5em;
 
 		font-size: 16px;
 		background-color: var(--color--page-background);
+		@include breakpoints.for-phone-only {
+			background-color: color-mix(in srgb, var(--color--page-background) 65%, transparent);
+		}
 		position: relative;
 		overflow: hidden;
 
@@ -60,6 +67,7 @@
 		gap: 20px 30px;
 		@include breakpoints.for-phone-only {
 			gap: 0;
+			
 		}
 		grid-template-columns: auto 1fr;
 		grid-template-areas:

--- a/src/lib/data/work-experiences.ts
+++ b/src/lib/data/work-experiences.ts
@@ -125,9 +125,9 @@ export const WORK_EXPERIENCE_LIST: WorkExperience[] = [
             {
                 title: 'Senior Front End Developer',
                 company: 'ELSO SERVICE BRNO, s.r.o.',
-                timeframe: '2025',
+                timeframe: '2025/26',
                 location: 'CZ, Brno',
-                current: false,
+                current: true,
                 skills: [],
                 description:
                     'Deployed as a Senior Frontend Developer to spearhead the delivery of a critical data platform for the Czech Statistical Office (ČSÚ). Architected the foundation of a shared application platform to unify internal tools while bootstrapping and upskilling the junior development team. Aided with migration of legacy software into a strictly typed React environment, introducing Jotai to orchestrate complex shared state across micro-apps.',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -48,7 +48,7 @@
         z-index: 3;
 
         @include breakpoints.for-phone-only {
-            padding: 40px 40px 20px;
+            padding: 50px 16px 20px;
         }
     }
 </style>


### PR DESCRIPTION
fixed mobile layout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CSS/markup tweaks for responsive layout plus a small resume data correction; low risk aside from potential visual regressions on small screens.
> 
> **Overview**
> Improves mobile responsiveness across the resume and navigation UI by adjusting phone breakpoints: `Header` uses a wider fixed nav bar, `+layout.svelte` tightens main-area side padding, and `Resume.svelte` drops the border and uses a more transparent background on phones (also fixes a `--color--text` typo).
> 
> Refactors `Experience.svelte` markup/styles to wrap location into a dedicated flex container and stack `company-info` vertically on phones while hiding separators, improving readability for both main roles and secondments.
> 
> Updates work experience data to mark the 2025/26 secondment as current and adjust its timeframe label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69f269e3b8a00de4504d90539f267edbe5ada0c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->